### PR TITLE
Set sqlite busy timeout of 10s

### DIFF
--- a/server/sqlite/pool.go
+++ b/server/sqlite/pool.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"errors"
+	"time"
 
 	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitemigration"
@@ -22,6 +23,8 @@ func CreatePool(ctx context.Context, uri string) (*Pool, error) {
 	pool := sqlitemigration.NewPool(uri, schema, sqlitemigration.Options{
 		PoolSize: 20,
 		PrepareConn: func(conn *sqlite.Conn) error {
+			conn.SetBusyTimeout(time.Second * 10)
+
 			return sqlitex.ExecuteTransient(conn, "PRAGMA foreign_keys = ON;", nil)
 		},
 		OnError: func(err error) {


### PR DESCRIPTION
Theoretically there should have been an infinite busy timeout, the sqlite package sets a busy handler that waits forever.

In practice, that didn't seem to be working, so let's try a busy timeout instead.