### PR TITLE
Simplify UI of Modify RSVP page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.8.0
+
+- Simplify UI of RSVP page
+
+Full changelog: [v0.7.0...v0.8.0](https://github.com/bradenrayhorn/ced/compare/v0.7.0...v0.8.0)
+
 ## v0.7.0
 
 - Add export command to CLI

--- a/ui/src/routes/modify/[id]/+page.svelte
+++ b/ui/src/routes/modify/[id]/+page.svelte
@@ -27,14 +27,12 @@
 </script>
 
 <svelte:head>
-  <title>Modify RSVP</title>
+  <title>RSVP - {group.name}</title>
 </svelte:head>
 
-<h1 class="h1">Modify RSVP</h1>
+<h2 class="mt-8 mb-5 h2">{group.name}</h2>
 
-<h3 class="mt-6 mb-2 h3">{group.name}</h3>
-
-<p class="mb-2">Please confirm the number of guests in your party.</p>
+<p class="mb-5">Please confirm the number of guests in your party.</p>
 
 <form
   method="POST"

--- a/ui/tests/modify.test.ts
+++ b/ui/tests/modify.test.ts
@@ -26,7 +26,7 @@ test("can complete an rsvp", async ({ prefix: { prefix }, page }) => {
   ).toHaveAttribute("href", "http://localhost:5555");
 
   await page.getByRole("link", { name: "Edit RSVP" }).click();
-  await expect(page).toHaveTitle("Modify RSVP");
+  await expect(page).toHaveTitle(`RSVP - ${prefix}Fred`);
 });
 
 test("can go back to search from modify page", async ({


### PR DESCRIPTION
The "Modify RSVP" title on the page is not necessary. 

The prompt to confirm the number of guests is enough to convey that they are RSVP-ing.